### PR TITLE
Collect C/C++ include directories from deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conan2"
-version = "0.1.0"
+version = "0.1.1"
 description = "Pulls the C/C++ library linking flags from Conan dependencies"
 authors = ["Sergey Kvachonok <ravenexp@gmail.com>"]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -69,3 +69,20 @@ fn main() {
         .emit();
 }
 ```
+
+## Getting C/C++ include paths from Conan dependencies
+
+To use the list of include paths, do the following after
+parsing the `conan install` output:
+
+```rust
+use conan2::ConanInstall;
+
+let metadata = ConanInstall::new().run().parse();
+
+for path in metadata.include_paths() {
+    // Add "-I{path}" to CXXFLAGS or something.
+}
+
+metadata.emit();
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,23 @@
 //!     .parse()
 //!     .emit();
 //! ```
+//!
+//! ## Getting C/C++ include paths from Conan dependencies
+//!
+//! To use the list of include paths, do the following after
+//! parsing the `conan install` output:
+//!
+//! ```no_run
+//! use conan2::ConanInstall;
+//!
+//! let metadata = ConanInstall::new().run().parse();
+//!
+//! for path in metadata.include_paths() {
+//!     // Add "-I{path}" to CXXFLAGS or something.
+//! }
+//!
+//! metadata.emit();
+//! ```
 
 #![deny(missing_docs)]
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -19,7 +19,12 @@ fn run_conan_install() {
     assert!(output.is_success());
     assert_eq!(output.status_code(), 0);
 
-    output.parse().emit();
+    let cargo = output.parse();
+    let includes = cargo.include_paths();
+
+    assert!(includes.len() > 3);
+
+    cargo.emit();
 }
 
 #[test]


### PR DESCRIPTION
Emit `cargo:include=DIR` metadata for Rust dependencies.

Add a new public method `CargoInstructions::include_paths()`.

Resolves #1 