### PR TITLE
feat: Add Conan command verbosity control option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,11 @@ can also be found in the project repository.
 
 ## Advanced usage
 
-Using custom Conan profiles with names derived from the Cargo target information:
+Using custom Conan profiles with names derived from the Cargo target information
+and a reduced output verbosity level:
 
 ```rust
-use conan2::ConanInstall;
+use conan2::{ConanInstall, ConanVerbosity};
 
 fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
@@ -64,6 +65,7 @@ fn main() {
     ConanInstall::new()
         .profile(&conan_profile)
         .build("missing")
+        .verbosity(ConanVerbosity::Error) // Silence Conan warnings
         .run()
         .parse()
         .emit();

--- a/example-build-script/build.rs
+++ b/example-build-script/build.rs
@@ -1,5 +1,10 @@
-use conan2::ConanInstall;
+use conan2::{ConanInstall, ConanVerbosity};
 
 fn main() {
-    ConanInstall::new().build("missing").run().parse().emit();
+    ConanInstall::new()
+        .build("missing")
+        .verbosity(ConanVerbosity::Error) // Silence Conan warnings
+        .run()
+        .parse()
+        .emit();
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,12 +2,13 @@
 
 use std::{io::Write, path::Path};
 
-use conan2::ConanInstall;
+use conan2::{ConanInstall, ConanVerbosity};
 
 #[test]
 fn run_conan_install() {
     let output = ConanInstall::with_recipe(Path::new("tests/conanfile.txt"))
         .output_folder(Path::new(env!("CARGO_TARGET_TMPDIR")))
+        .verbosity(ConanVerbosity::Verbose)
         .build("missing")
         .run();
 
@@ -31,6 +32,7 @@ fn run_conan_install() {
 fn fail_no_conanfile() {
     let output = ConanInstall::new()
         .output_folder(Path::new(env!("CARGO_TARGET_TMPDIR")))
+        .verbosity(ConanVerbosity::Status)
         .run();
 
     std::io::stderr().write_all(output.stderr()).unwrap();
@@ -48,6 +50,7 @@ fn fail_no_profile() {
     let output = ConanInstall::with_recipe(Path::new("tests/conanfile.txt"))
         .output_folder(Path::new(env!("CARGO_TARGET_TMPDIR")))
         .profile("no-such-profile")
+        .verbosity(ConanVerbosity::Debug)
         .run();
 
     std::io::stderr().write_all(output.stderr()).unwrap();


### PR DESCRIPTION
Add a new `conan install` command builder method `verbosity()` and a public enumeration defining the verbosity levels.

Resolves #4