### PR TITLE
Add `ConanInstall::build_profile()` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conan2"
-version = "0.1.2"
+version = "0.1.3"
 description = "Pulls the C/C++ library linking flags from Conan dependencies"
 authors = ["Sergey Kvachonok <ravenexp@gmail.com>"]
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ can also be found in the project repository.
 
 ## Advanced usage
 
+### Automatic Conan profile inference from Cargo target
+
 Using custom Conan profiles with names derived from the Cargo target information
 and a reduced output verbosity level:
 
@@ -64,7 +66,6 @@ fn main() {
 
     ConanInstall::new()
         .profile(&conan_profile)
-        .detect_profile() // Auto-detect if the profile does not exist
         .build("missing")
         .verbosity(ConanVerbosity::Error) // Silence Conan warnings
         .run()
@@ -73,7 +74,38 @@ fn main() {
 }
 ```
 
-## Getting C/C++ include paths from Conan dependencies
+### Automatic Conan profile creation
+
+Creating a custom default Conan profile on the fly with zero configuration:
+
+```rust
+use conan2::{ConanInstall, ConanVerbosity};
+
+ConanInstall::new()
+    .profile("cargo")
+    .detect_profile() // Run `conan profile detect --exist-ok` for the above
+    .run()
+    .parse()
+    .emit();
+```
+
+### Using separate host and build profiles
+
+Using different values for `--profile:host` and `--profile:build`
+arguments of `conan install` command:
+
+```rust
+use conan2::{ConanInstall, ConanVerbosity};
+
+ConanInstall::new()
+    .host_profile("cargo-host")
+    .build_profile("cargo-build")
+    .run()
+    .parse()
+    .emit();
+```
+
+### Getting C/C++ include paths from Conan dependencies
 
 To use the list of include paths, do the following after
 parsing the `conan install` output:

--- a/example-build-script/build.rs
+++ b/example-build-script/build.rs
@@ -2,7 +2,10 @@ use conan2::{ConanInstall, ConanVerbosity};
 
 fn main() {
     ConanInstall::new()
-        .detect_profile() // Auto-detect "default" profile if not exists
+        .host_profile("cargo-host")
+        .build_profile("default")
+        // Auto-detect "cargo-host" and "default" profiles if none exist
+        .detect_profile()
         .build("missing")
         .verbosity(ConanVerbosity::Error) // Silence Conan warnings
         .run()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,15 +350,20 @@ impl ConanInstall {
         command.arg("profile").arg("detect").arg("--exist-ok");
 
         if let Some(profile) = profile {
+            println!("running 'conan profile detect' for profile '{profile}'");
+
             command.arg("--name").arg(profile);
+        } else {
+            println!("running 'conan profile detect' for the default profile");
         }
 
         let status = command
             .status()
             .expect("failed to run the Conan executable");
 
+        #[allow(clippy::manual_assert)]
         if !status.success() {
-            panic!("conan profile detect command failed: {}", status);
+            panic!("'conan profile detect' command failed: {status}");
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@
 //!
 //! ## Advanced usage
 //!
+//! ### Automatic Conan profile inference from Cargo target
+//!
 //! Using custom Conan profiles with names derived from the Cargo target information
 //! and a reduced output verbosity level:
 //!
@@ -58,7 +60,6 @@
 //!
 //! ConanInstall::new()
 //!     .profile(&conan_profile)
-//!     .detect_profile() // Auto-detect if the profile does not exist
 //!     .build("missing")
 //!     .verbosity(ConanVerbosity::Error) // Silence Conan warnings
 //!     .run()
@@ -66,7 +67,38 @@
 //!     .emit();
 //! ```
 //!
-//! ## Getting C/C++ include paths from Conan dependencies
+//! ### Automatic Conan profile creation
+//!
+//! Creating a custom default Conan profile on the fly with zero configuration:
+//!
+//! ```no_run
+//! use conan2::{ConanInstall, ConanVerbosity};
+//!
+//! ConanInstall::new()
+//!     .profile("cargo")
+//!     .detect_profile() // Run `conan profile detect --exist-ok` for the above
+//!     .run()
+//!     .parse()
+//!     .emit();
+//! ```
+//!
+//! ### Using separate host and build profiles
+//!
+//! Using different values for `--profile:host` and `--profile:build`
+//! arguments of `conan install` command:
+//!
+//! ```no_run
+//! use conan2::{ConanInstall, ConanVerbosity};
+//!
+//! ConanInstall::new()
+//!     .host_profile("cargo-host")
+//!     .build_profile("cargo-build")
+//!     .run()
+//!     .parse()
+//!     .emit();
+//! ```
+//!
+//! ### Getting C/C++ include paths from Conan dependencies
 //!
 //! To use the list of include paths, do the following after
 //! parsing the `conan install` output:

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -75,3 +75,18 @@ fn detect_custom_profile() {
     std::io::stderr().write_all(output.stderr()).unwrap();
     assert!(output.is_success());
 }
+
+#[test]
+fn host_and_build_profiles() {
+    let output = ConanInstall::with_recipe(Path::new("tests/conanfile.txt"))
+        .output_folder(Path::new(env!("CARGO_TARGET_TMPDIR")))
+        .host_profile(&format!("{}-dynamic-host-profile", env!("CARGO_PKG_NAME")))
+        .build_profile(&format!("{}-dynamic-build-profile", env!("CARGO_PKG_NAME")))
+        .detect_profile()
+        .build("missing")
+        .verbosity(ConanVerbosity::Debug)
+        .run();
+
+    std::io::stderr().write_all(output.stderr()).unwrap();
+    assert!(output.is_success());
+}


### PR DESCRIPTION
Allow setting Conan build profile along with the host profile.

Add an alias `ConanInstall::host_profile()` for `ConanInstall::profile()`.

Resolves #10 
