### PR TITLE
chore(release): prepare for v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.5] - 2024-12-21
+
+### 🚀 Features
+
+- Support for `sharedlinkflags`
+
+### 🧪 Testing
+
+- Add `sharedlinkflags` to integration test
+
 ## [0.1.4] - 2024-11-28
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conan2"
-version = "0.1.4"
+version = "0.1.5"
 description = "Pulls the C/C++ library linking flags from Conan dependencies"
 authors = ["Sergey Kvachonok <ravenexp@gmail.com>"]
 edition = "2021"


### PR DESCRIPTION
Bump the crate version and update CHANGELOG.