### PR TITLE
Process header-only dependencies normally

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ is to add a plain `conanfile.txt` file as follows:
 
 ```text
 [requires]
-libxml2/2.11.4
-openssl/3.1.3
-zlib/1.3
+libxml2/2.13.8
+openssl/3.4.1
+zlib/1.3.1
 ```
 
 ## Example usage

--- a/example-build-script/conanfile.txt
+++ b/example-build-script/conanfile.txt
@@ -1,4 +1,4 @@
 [requires]
-zlib/1.3
-libxml2/2.11.4
-openssl/3.1.3
+zlib/1.3.1
+libxml2/2.13.8
+openssl/3.4.1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@
 //!
 //! ```text
 //! [requires]
-//! libxml2/2.11.4
-//! openssl/3.1.3
-//! zlib/1.3
+//! libxml2/2.13.8
+//! openssl/3.4.1
+//! zlib/1.3.1
 //! ```
 //!
 //! ## Example usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,30 +573,21 @@ impl ConanDependencyGraph {
             return;
         };
 
-        // Skip dependency components which provide no C/C++ libraries.
-        let Some(Value::Array(libs)) = component.get("libs") else {
-            return;
-        };
-        if libs.is_empty() {
-            return;
-        }
-
-        // Skip dependency components which provide no library paths.
-        let Some(Value::Array(libdirs)) = component.get("libdirs") else {
-            return;
-        };
-
         // 1. Emit linker search directory instructions for `rustc`.
-        for libdir in libdirs {
-            if let Value::String(libdir) = libdir {
-                cargo.rustc_link_search(libdir);
+        if let Some(Value::Array(libdirs)) = component.get("libdirs") {
+            for libdir in libdirs {
+                if let Value::String(libdir) = libdir {
+                    cargo.rustc_link_search(libdir);
+                }
             }
         }
 
         // 2. Emit library link instructions for `rustc`.
-        for lib in libs {
-            if let Value::String(lib) = lib {
-                cargo.rustc_link_lib(lib);
+        if let Some(Value::Array(libs)) = component.get("libs") {
+            for lib in libs {
+                if let Value::String(lib) = lib {
+                    cargo.rustc_link_lib(lib);
+                }
             }
         }
 

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-zlib/1.3
-libxml2/2.11.4
-openssl/3.1.3
+zlib/1.3.1
+libxml2/2.13.8
+openssl/3.4.1
 lightgbm/4.3.0


### PR DESCRIPTION
Do not silently drop dependencies that contain no object libraries.