### PR TITLE
Support library file names in `cpp_info.libs`

### DIFF
--- a/example-build-script/build.rs
+++ b/example-build-script/build.rs
@@ -1,6 +1,16 @@
+use std::process::Command;
+
 use conan2::{ConanInstall, ConanVerbosity};
 
 fn main() {
+    let status = Command::new("conan")
+        .arg("create")
+        .arg("test_pkg_conanfile.py")
+        .status()
+        .expect("failed to create test package");
+
+    assert!(status.success(), "creating test package failed");
+
     ConanInstall::new()
         .host_profile("cargo-host")
         .build_profile("default")

--- a/example-build-script/conanfile.txt
+++ b/example-build-script/conanfile.txt
@@ -2,3 +2,4 @@
 zlib/1.3.1
 libxml2/2.13.8
 openssl/3.4.1
+system_libs_test/0.1.0

--- a/example-build-script/src/main.rs
+++ b/example-build-script/src/main.rs
@@ -18,6 +18,12 @@ extern "C" {
 
     /// libssl
     fn OPENSSL_init_ssl(opts: u64, buf: *const c_void) -> c_int;
+
+    /// libsqlite3
+    fn sqlite3_libversion() -> *const u8;
+
+    /// libyaml
+    fn yaml_get_version_string() -> *const u8;
 }
 
 fn main() {
@@ -39,5 +45,11 @@ fn main() {
 
         // libssl
         OPENSSL_init_ssl(0, std::ptr::null());
+
+        // libsqlite3
+        sqlite3_libversion();
+
+        // libyaml
+        yaml_get_version_string();
     };
 }

--- a/example-build-script/test_pkg_conanfile.py
+++ b/example-build-script/test_pkg_conanfile.py
@@ -1,0 +1,18 @@
+from conan import ConanFile
+
+
+class TestSystemLibsConan(ConanFile):
+    """
+    Defines a Conan package for the cpp_info.system_libs attribute tests.
+    """
+
+    name = "system_libs_test"
+    version = "0.1.0"
+
+    package_type = "static-library"
+    build_policy = "missing"
+
+    settings = "os", "compiler", "build_type", "arch"
+
+    def package_info(self):
+        self.cpp_info.system_libs = ["libyaml.so", "libsqlite3.a"]


### PR DESCRIPTION
When a Conan dependency package uses a plain library file name such as `libfoo.a` or `libbar.so` in its `cpp_info.libs` or `cpp_info.system_libs` package attributes, broken GNU linker flags such as `-llibfoo.a` were generated by the build scripts.

In contrast, Conan with CMake-based generators can handle linking of such dependency packages correctly.

Convert library file names into library names and linking kind modifiers automatically, just like CMake does.

Resolves #9