### PR TITLE
Release: prepare for v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2025-05-20
+
+### 🚀 Features
+
+- Support library file names in `cpp_info.libs`
+
+### 🐛 Bug Fixes
+
+- Process header-only dependencies normally
+
+### 🧪 Testing
+
+- Update dependencies in test Conanfiles
+- Add a test case for `cpp_info.system_libs`
+
 ## [0.1.5] - 2024-12-21
 
 ### 🚀 Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conan2"
-version = "0.1.5"
+version = "0.1.6"
 description = "Pulls the C/C++ library linking flags from Conan dependencies"
 authors = ["Sergey Kvachonok <ravenexp@gmail.com>"]
 edition = "2021"


### PR DESCRIPTION
Bump the crate version and update CHANGELOG.