### PR TITLE
feat: Add "build_type" setting configuration method

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ fn main() {
 ```
 
 The most commonly used `build_type` Conan setting will be defined automatically
-depending on the current Cargo build profile: Debug or Release.
+depending on the current Cargo build profile: `debug` or `release`.
 
 The Conan executable is assumed to be named `conan` unless
 the `CONAN` environment variable is set to override.
@@ -66,6 +66,7 @@ fn main() {
 
     ConanInstall::new()
         .profile(&conan_profile)
+        .build_type("RelWithDebInfo") // Override the Cargo build profile
         .build("missing")
         .verbosity(ConanVerbosity::Error) // Silence Conan warnings
         .run()

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -9,8 +9,9 @@ fn run_conan_install() {
     let output = ConanInstall::with_recipe(Path::new("tests/conanfile.txt"))
         .output_folder(Path::new(env!("CARGO_TARGET_TMPDIR")))
         .detect_profile() // Auto-detect "default" profile if not exists
-        .verbosity(ConanVerbosity::Verbose)
+        .build_type("Release")
         .build("missing")
+        .verbosity(ConanVerbosity::Verbose)
         .run();
 
     // Fallback for test debugging
@@ -33,6 +34,7 @@ fn run_conan_install() {
 fn fail_no_conanfile() {
     let output = ConanInstall::new()
         .output_folder(Path::new(env!("CARGO_TARGET_TMPDIR")))
+        .build_type("Debug")
         .verbosity(ConanVerbosity::Status)
         .run();
 
@@ -68,6 +70,7 @@ fn detect_custom_profile() {
         .output_folder(Path::new(env!("CARGO_TARGET_TMPDIR")))
         .profile(&format!("{}-dynamic-profile", env!("CARGO_PKG_NAME")))
         .detect_profile()
+        .build_type("RelWithDebInfo")
         .build("missing")
         .verbosity(ConanVerbosity::Debug)
         .run();


### PR DESCRIPTION
Add a new `ConanInstall` builder method `build_type()`. Default to the Cargo build profile type from the environment.