### PR TITLE
Add support for setting package build options

### DIFF
--- a/example-build-script/build.rs
+++ b/example-build-script/build.rs
@@ -1,6 +1,6 @@
 use std::process::Command;
 
-use conan2::{ConanInstall, ConanVerbosity};
+use conan2::{ConanInstall, ConanScope, ConanVerbosity};
 
 fn main() {
     let status = Command::new("conan")
@@ -18,6 +18,10 @@ fn main() {
         .detect_profile()
         .build("missing")
         .verbosity(ConanVerbosity::Error) // Silence Conan warnings
+        .option(ConanScope::Global, "shared", "False")
+        .option(ConanScope::Local, "sanitizers", "True")
+        .option(ConanScope::Package("openssl"), "no_deprecated", "True")
+        .option(ConanScope::Package("libxml2/2.13.8"), "ftp", "False")
         .run()
         .parse()
         .emit();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,7 @@
 
 use std::{io::Write, path::Path};
 
-use conan2::{ConanInstall, ConanVerbosity};
+use conan2::{ConanInstall, ConanScope, ConanVerbosity};
 
 #[test]
 fn run_conan_install() {
@@ -12,6 +12,10 @@ fn run_conan_install() {
         .build_type("Release")
         .build("missing")
         .verbosity(ConanVerbosity::Verbose)
+        .option(ConanScope::Global, "shared", "True")
+        .option(ConanScope::Local, "sanitizers", "True")
+        .option(ConanScope::Package("openssl"), "no_deprecated", "True")
+        .option(ConanScope::Package("libxml2/2.13.8"), "ftp", "False")
         .run();
 
     // Fallback for test debugging


### PR DESCRIPTION
Add a new `ConanInstall` builder method `option()`.

Add a new helper enum type for defining the package build options scope.