### PR TITLE
Add support for setting Conan config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Using custom Conan profiles with names derived from the Cargo target information
 and a reduced output verbosity level:
 
 ```rust
-use conan2::{ConanInstall, ConanVerbosity};
+use conan2::{ConanInstall, ConanScope, ConanVerbosity};
 
 fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
@@ -69,6 +69,11 @@ fn main() {
         .build_type("RelWithDebInfo") // Override the Cargo build profile
         .build("missing")
         .verbosity(ConanVerbosity::Error) // Silence Conan warnings
+        .option(ConanScope::Global, "shared", "True") // Add some package options
+        .option(ConanScope::Local, "power", "10")
+        .option(ConanScope::Package("foolib"), "frob", "max")
+        .option(ConanScope::Package("barlib/1.0"), "zoom", "True")
+        .config("tools.build:skip_test", "True") // Add some Conan configs
         .run()
         .parse()
         .emit();

--- a/example-build-script/build.rs
+++ b/example-build-script/build.rs
@@ -22,6 +22,7 @@ fn main() {
         .option(ConanScope::Local, "sanitizers", "True")
         .option(ConanScope::Package("openssl"), "no_deprecated", "True")
         .option(ConanScope::Package("libxml2/2.13.8"), "ftp", "False")
+        .config("tools.build:skip_test", "True")
         .run()
         .parse()
         .emit();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,6 +16,7 @@ fn run_conan_install() {
         .option(ConanScope::Local, "sanitizers", "True")
         .option(ConanScope::Package("openssl"), "no_deprecated", "True")
         .option(ConanScope::Package("libxml2/2.13.8"), "ftp", "False")
+        .config("tools.build:skip_test", "True")
         .run();
 
     // Fallback for test debugging


### PR DESCRIPTION
Add a new `ConanInstall` builder method `config()`.